### PR TITLE
Update README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To run the supplied unit tests for **CryptorRSA** from the command line:
 To include BlueRSA into a Swift Package Manager package, add it to the `dependencies` attribute defined in your `Package.swift` file. You can select the version using the `majorVersion` and `minor` parameters. For example:
 ```
 	dependencies: [
-		.Package(url: "https://github.com/IBM-Swift/BlueRSA", majorVersion: <majorVersion>, minor: <minor>)
+		.package(url: "https://github.com/IBM-Swift/BlueRSA", majorVersion: <majorVersion>, minor: <minor>)
 	]
 ```
 


### PR DESCRIPTION
Package.Dependency has a member "package" with lowercase p

<!--- Provide a general summary of your changes in the Title above -->
Fixed typo

## Description
<!--- Describe your changes in detail -->

Replaced lowercase "p" with uppercase "P"

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

With uppercase member "Package", the command swift package update produces the following
error: type 'Package.Dependency' has no member 'Package'

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested before and after.
Before, with uppercase P there was an error.
After, with lowercase, the error is resolved and the command executes as expected.
<!--- Include details of your testing environment, and the tests you ran to -->
Bash shell, terminal command 'swift package update'
<!--- see how your change affects other areas of the code, etc. -->
Not applicable
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
I received a delivery has failed notification after sending the form via email
- [x ] If applicable, I have updated the documentation accordingly.
- [x ] If applicable, I have added tests to cover my changes.